### PR TITLE
fix: Remove Cognifide logo, update company name

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2012 Cognifide Polska Sp. z o. o.
+Copyright 2012 Wunderman Thompson Technology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![Cognifide logo](http://cognifide.github.io/images/cognifide-logo.png)
-
 ![Carty logo](http://cognifide.github.io/Carty/assets/media/logo-carty.png)
 
 ## Purpose

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Carty</name>
-    <description>Cognifide mapping tool</description>
-    <url>https://github.com/Cognifide/Carty</url>
+    <description>Wunderman Thompson Technology mapping tool</description>
+    <url>https://github.com/wttech/Carty</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,13 +26,13 @@
     </properties>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com:Cognifide/Carty.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:Cognifide/Carty.git</developerConnection>
-        <url>https://github.com/Cognifide/Carty</url>
+        <connection>scm:git:ssh://git@github.com:wttech/Carty.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:wttech/Carty.git</developerConnection>
+        <url>https://github.com/wttech/Carty</url>
     </scm>
 
     <organization>
-        <name>Cognifide</name>
+        <name>Wunderman Thompson Technology</name>
         <url>http://www.cognifide.com</url>
     </organization>
 


### PR DESCRIPTION
Changes related to the ownership transfer. Move Cognifide references to Wunderman Thompson Technology, remove old logo